### PR TITLE
Remove logging in production mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@ const colors = require('colors');
 //Error Log
 const autoLogE = (message, vars) => {
 
+    // If the process is running in 'production', stop logging.
+    if (process.env.NODE_ENV === "production") return;
+
     //Creating Error to get name of function
     let stack = new Error().stack
     let caller = stack.split('\n')[2].trim();
@@ -27,6 +30,9 @@ const autoLogE = (message, vars) => {
 
 //Info Log
 const autoLogI = (message, vars) => {
+
+    // If the process is running in 'production', stop logging.
+    if (process.env.NODE_ENV === "production") return;
 
     //Creating Error to get name of function
     let stack = new Error().stack
@@ -53,6 +59,9 @@ const autoLogI = (message, vars) => {
 
 //Warning Log
 const autoLogW = (message, vars) => {
+
+    // If the process is running in 'production', stop logging.
+    if (process.env.NODE_ENV === "production") return;
 
     //Creating Error to get name of function
     let stack = new Error().stack


### PR DESCRIPTION
These are the required changes for stopping the program from logging into the 'production' environment.

**What I Have Done?**
- Check if the environmental variable for NODE_ENV is set to production, if yes then just return.

Related Issue #2 